### PR TITLE
[FEAT] 홈 - 교통, 안전 및 치안, 시각화(임시) 페이지 구현

### DIFF
--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -4,10 +4,10 @@
     <selectionStates>
       <SelectionState runConfigName="app">
         <option name="selectionMode" value="DROPDOWN" />
-        <DropdownSelection timestamp="2025-02-26T15:10:19.104311100Z">
+        <DropdownSelection timestamp="2025-02-26T18:26:55.677003Z">
           <Target type="DEFAULT_BOOT">
             <handle>
-              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\82102\.android\avd\Pixel_8_API_34.avd" />
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Users\82102\.android\avd\Pixel_7_API_34.avd" />
             </handle>
           </Target>
         </DropdownSelection>

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/datasource/HomeDataSource.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/datasource/HomeDataSource.kt
@@ -1,11 +1,20 @@
 package com.example.seollyongdan_frontend.data.datasource
 
 import com.example.seollyongdan_frontend.data.dto.SeollyongdanBaseResponse
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCongestionDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCrimeFreqDto
 import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeSafetyDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeTrafficDto
 
 interface HomeDataSource {
 
     suspend fun getHomeSafety(townId : Int) : SeollyongdanBaseResponse<ResponseHomeSafetyDto>
+
+    suspend fun getHomeTraffic(townId: Int) : SeollyongdanBaseResponse<ResponseHomeTrafficDto>
+
+    suspend fun getHomeCrimeFreq() : SeollyongdanBaseResponse<ResponseHomeCrimeFreqDto>
+
+    suspend fun getHomeCongestion() : SeollyongdanBaseResponse<ResponseHomeCongestionDto>
 
 
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/datasourceimpl/HomeDataSourceImpl.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/datasourceimpl/HomeDataSourceImpl.kt
@@ -2,7 +2,10 @@ package com.example.seollyongdan_frontend.data.datasourceimpl
 
 import com.example.seollyongdan_frontend.data.datasource.HomeDataSource
 import com.example.seollyongdan_frontend.data.dto.SeollyongdanBaseResponse
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCongestionDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCrimeFreqDto
 import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeSafetyDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeTrafficDto
 import com.example.seollyongdan_frontend.data.service.HomeApiService
 import javax.inject.Inject
 
@@ -12,5 +15,17 @@ class HomeDataSourceImpl @Inject constructor(
 
     override suspend fun getHomeSafety(townId: Int): SeollyongdanBaseResponse<ResponseHomeSafetyDto> {
         return homeApiService.getTownSafety(townId)
+    }
+
+    override suspend fun getHomeTraffic(townId: Int): SeollyongdanBaseResponse<ResponseHomeTrafficDto> {
+        return homeApiService.getTownTraffic(townId)
+    }
+
+    override suspend fun getHomeCrimeFreq(): SeollyongdanBaseResponse<ResponseHomeCrimeFreqDto> {
+        return homeApiService.getHomeCrimeFreq()
+    }
+
+    override suspend fun getHomeCongestion(): SeollyongdanBaseResponse<ResponseHomeCongestionDto> {
+        return homeApiService.getHomeCongestion()
     }
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/dto/response/ResponseHomeCongestionDto.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/dto/response/ResponseHomeCongestionDto.kt
@@ -1,0 +1,13 @@
+package com.example.seollyongdan_frontend.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseHomeCongestionDto(
+    val roadCongestion : List<CongestionDto>
+)
+
+@Serializable
+data class CongestionDto(
+    val roadCongestion : String
+)

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/dto/response/ResponseHomeCrimeFrepDto.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/dto/response/ResponseHomeCrimeFrepDto.kt
@@ -1,0 +1,13 @@
+package com.example.seollyongdan_frontend.data.dto.response
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseHomeCrimeFreqDto(
+    val crimeFrequency : List<CrimeFreqDto>
+)
+
+@Serializable
+data class CrimeFreqDto(
+    val crimeFrequency : String
+)

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/dto/response/ResponseHomeTrafficDto.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/dto/response/ResponseHomeTrafficDto.kt
@@ -1,0 +1,14 @@
+package com.example.seollyongdan_frontend.data.dto.response
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ResponseHomeTrafficDto(
+    @SerialName("townId") val townId : Int,
+    @SerialName("busRatio") val busRatio : Float,
+    @SerialName("subwayRatio") val subwayRatio : Float,
+    @SerialName("taxiRatio") val taxiRatio : Float,
+    @SerialName("mostUsedTransport") val mostUsedTransport : String,
+    @SerialName("highCongestion") val isHigh : Boolean
+)

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/repositoryimpl/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/repositoryimpl/HomeRepositoryImpl.kt
@@ -1,7 +1,10 @@
 package com.example.seollyongdan_frontend.data.repositoryimpl
 
 import com.example.seollyongdan_frontend.data.datasource.HomeDataSource
+import com.example.seollyongdan_frontend.data.dto.response.CrimeFreqDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCrimeFreqDto
 import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeSafetyDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeTrafficDto
 import com.example.seollyongdan_frontend.domain.repository.HomeRepository
 import javax.inject.Inject
 
@@ -26,4 +29,42 @@ class HomeRepositoryImpl @Inject constructor(
             )
         }
     }
+
+    override suspend fun getHomeTraffic(townId: Int): Result<ResponseHomeTrafficDto> {
+        return runCatching {
+            val response = homeDataSource.getHomeTraffic(townId)
+
+            val result = response.result ?: throw Exception("Result is null")
+
+            ResponseHomeTrafficDto(
+                townId = result.townId,
+                busRatio = result.busRatio,
+                subwayRatio = result.subwayRatio,
+                taxiRatio = result.taxiRatio,
+                mostUsedTransport = result.mostUsedTransport,
+                isHigh = result.isHigh
+            )
+        }
+    }
+
+    override suspend fun getHomeCrimeFreq(): Result<List<String>> {
+        return runCatching {
+            val response = homeDataSource.getHomeCrimeFreq()
+
+            val result = response.result ?: throw Exception("Result is null")
+
+            result.crimeFrequency.map { it.crimeFrequency }
+        }
+    }
+
+    override suspend fun getHomeCongestion(): Result<List<String>> {
+        return kotlin.runCatching {
+            val response = homeDataSource.getHomeCongestion()
+            val result = response.result ?: throw Exception("Result is null")
+
+            result.roadCongestion.map { it.roadCongestion }
+
+        }
+    }
+
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/service/ApiKeyStorage.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/service/ApiKeyStorage.kt
@@ -29,6 +29,9 @@ object ApiKeyStorage {
     const val CHECKNICKNAME = "check-nickname"
     const val TOWN = "town"
     const val SAFETY = "safety"
+    const val TRANSPORT = "transport"
+    const val CRIMEFREQ = "crime-freq"
+    const val CONGESTION = "congestion"
 
 }
 

--- a/app/src/main/java/com/example/seollyongdan_frontend/data/service/HomeApiService.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/data/service/HomeApiService.kt
@@ -1,10 +1,16 @@
 package com.example.seollyongdan_frontend.data.service
 
 import com.example.seollyongdan_frontend.data.dto.SeollyongdanBaseResponse
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCongestionDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCrimeFreqDto
 import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeSafetyDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeTrafficDto
 import com.example.seollyongdan_frontend.data.service.ApiKeyStorage.API
+import com.example.seollyongdan_frontend.data.service.ApiKeyStorage.CONGESTION
+import com.example.seollyongdan_frontend.data.service.ApiKeyStorage.CRIMEFREQ
 import com.example.seollyongdan_frontend.data.service.ApiKeyStorage.SAFETY
 import com.example.seollyongdan_frontend.data.service.ApiKeyStorage.TOWN
+import com.example.seollyongdan_frontend.data.service.ApiKeyStorage.TRANSPORT
 import retrofit2.http.GET
 import retrofit2.http.Path
 
@@ -14,4 +20,15 @@ interface HomeApiService {
     suspend fun getTownSafety(
         @Path("town-id") townId : Int
     ) : SeollyongdanBaseResponse<ResponseHomeSafetyDto>
+
+    @GET("/$API/$TOWN/{town-id}/$TRANSPORT")
+    suspend fun getTownTraffic(
+        @Path("town-id") townId : Int
+    ) : SeollyongdanBaseResponse<ResponseHomeTrafficDto>
+
+    @GET("/$API/$TOWN/$CRIMEFREQ")
+    suspend fun getHomeCrimeFreq() : SeollyongdanBaseResponse<ResponseHomeCrimeFreqDto>
+
+    @GET("/$API/$TOWN/$CONGESTION")
+    suspend fun getHomeCongestion() : SeollyongdanBaseResponse<ResponseHomeCongestionDto>
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/domain/repository/HomeRepository.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/domain/repository/HomeRepository.kt
@@ -1,10 +1,17 @@
 package com.example.seollyongdan_frontend.domain.repository
 
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeCrimeFreqDto
 import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeSafetyDto
+import com.example.seollyongdan_frontend.data.dto.response.ResponseHomeTrafficDto
 
 interface HomeRepository {
 
     suspend fun getHomeSafety(townId : Int) : Result<ResponseHomeSafetyDto>
 
+    suspend fun getHomeTraffic(townId : Int) : Result<ResponseHomeTrafficDto>
+
+    suspend fun getHomeCrimeFreq() : Result<List<String>>
+
+    suspend fun getHomeCongestion() : Result<List<String>>
 
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/navigation/HomeNavGraph.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/navigation/HomeNavGraph.kt
@@ -4,7 +4,9 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.example.seollyongdan_frontend.presentation.home.screen.HomeRoute
 import com.example.seollyongdan_frontend.presentation.home.screen.SafetyVisualizationRoute
+import com.example.seollyongdan_frontend.presentation.home.screen.SafetyVisualizationTempRoute
 import com.example.seollyongdan_frontend.presentation.home.screen.TrafficVisualizationRoute
+import com.example.seollyongdan_frontend.presentation.home.screen.TrafficVisualizationTempRoute
 
 
 fun NavGraphBuilder.homeNavGraph(
@@ -20,5 +22,13 @@ fun NavGraphBuilder.homeNavGraph(
 
     composable(route = "safetyVisualization"){
         SafetyVisualizationRoute(navigator = navigator)
+    }
+
+    composable(route = "trafficVisualizationTemp"){
+        TrafficVisualizationTempRoute(navigator = navigator)
+    }
+
+    composable(route = "safetyVisualizationTemp"){
+        SafetyVisualizationTempRoute(navigator = navigator)
     }
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/navigation/HomeNavigator.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/navigation/HomeNavigator.kt
@@ -23,4 +23,12 @@ class HomeNavigator(
     fun navigateToSafetyVisualization() {
         navController.navigate("safetyVisualization")
     }
+
+    fun navigateToTrafficVisualizationTemp() {
+        navController.navigate("trafficVisualizationTemp")
+    }
+
+    fun navigateToSafetyVisualizationTemp() {
+        navController.navigate("safetyVisualizationTemp")
+    }
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/BottomSheetSwitcher.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/BottomSheetSwitcher.kt
@@ -8,6 +8,7 @@ fun BottomSheetSwitcher(
     screen: BottomSheetScreen,
     homeViewModel: HomeViewModel,
     safetyViewModel: SafetyViewModel,
+    trafficViewModel: TrafficViewModel,
     onSearchClick : () -> Unit,
     onTrafficVisualizationClick : () -> Unit,
     onSafetyVisualizationClick : () -> Unit,
@@ -19,6 +20,6 @@ fun BottomSheetSwitcher(
         BottomSheetScreen.LIFE -> BottomSheetLifeScreen(homeViewModel, districtName)
         BottomSheetScreen.REVIEW -> BottomSheetReviewScreen(homeViewModel, districtName)
         BottomSheetScreen.SAFETY -> BottomSheetSafetyScreen(homeViewModel, safetyViewModel, districtName, onSafetyVisualizationClick)
-        BottomSheetScreen.TRAFFIC -> BottomSheetTrafficScreen(homeViewModel, districtName, onTrafficVisualizationClick)
+        BottomSheetScreen.TRAFFIC -> BottomSheetTrafficScreen(homeViewModel, trafficViewModel, districtName, onTrafficVisualizationClick)
     }
 }

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/BottomSheetTrafficScreen.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/BottomSheetTrafficScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -42,18 +43,25 @@ import com.example.seollyongdan_frontend.ui.theme.h7Semi
 @Composable
 fun BottomSheetTrafficScreen(
     homeViewModel: HomeViewModel,
+    trafficViewModel: TrafficViewModel,
     districtName: String,
     onTrafficVisualizationClick : () -> Unit
 ) {
+    val townId = townNameToId(districtName)
+
+    LaunchedEffect(districtName){
+        trafficViewModel.getHomeTraffic(townId)
+    }
+
     val onBackClick = { homeViewModel.setBottomSheetScreen(BottomSheetScreen.HOME) }
 
-    val trafficTrue = true //혼잡도 상위 5위 여부 - 백엔드에서 받아오는 형태로 수정 필dt
+    val trafficTrue = trafficViewModel.isHigh //혼잡도 상위 5위 여부
 
     val trafficDistricts = listOf("강남구", "중구", "성북구", "송파구", "동작구", "기타")
     val trafficValues = listOf(30f, 20f, 15f, 10f, 15f, 10f)
 
-    val trafficTableData = listOf("60", "40") //해당 구 대중교통 이용 비율 - 백엔드에서 받아오는 형태로 수정 필요
-    val trafficMajor = 1 //1이면 버스, 2면 지하철을 더 사용 - 백엔드에서 받아오는 형태로 수정 필요
+    val trafficTableData = listOf(trafficViewModel.busRatio.toString(), trafficViewModel.subwayRatio.toString(), trafficViewModel.taxiRatio.toString()) //해당 구 대중교통 이용 비율 - 백엔드에서 받아오는 형태로 수정 필요
+    val trafficMajor = trafficViewModel.mostUsedTransport
 
 
 
@@ -94,7 +102,7 @@ fun BottomSheetTrafficScreen(
 
         Box(
             modifier = Modifier
-                .height(235.dp)
+                .height(280.dp)
                 .fillMaxWidth()
                 .clip(RoundedCornerShape(30.dp))
                 .background(Success500)
@@ -116,12 +124,7 @@ fun BottomSheetTrafficScreen(
                 Text(text = buildAnnotatedString {
                     append("$districtName 주민들은 ")
                     withStyle(style = SpanStyle(color = Success800)) {
-                        if (trafficMajor==1){
-                            append("버스를 더 많이 이용해요")
-                        }
-                        else {
-                            append("지하철을 더 많이 이용해요")
-                        }
+                        append("{$trafficMajor}를 가장 많이 이용해요")
                     }
                 }, style = h7Semi)
 
@@ -151,7 +154,6 @@ fun BottomSheetTrafficScreen(
                         PieGraph(data = trafficValues, labels = trafficDistricts)
                     }
 
-                    //Spacer(modifier = Modifier.height(10.dp))
 
                     Text(text = buildAnnotatedString {
                         append("서울시 기준 혼잡도 ")
@@ -182,6 +184,7 @@ fun BottomSheetTrafficScreen(
 fun TrafficScreenPreview() {
     BottomSheetTrafficScreen(
         homeViewModel = viewModel(),
+        trafficViewModel = viewModel(),
         districtName = "성북구",
         onTrafficVisualizationClick = {}
     )

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/HomeScreen.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/HomeScreen.kt
@@ -57,6 +57,7 @@ fun HomeRoute(
     val systemUiController = rememberSystemUiController()
     val homeViewModel: HomeViewModel = hiltViewModel()
     val safetyViewModel: SafetyViewModel = hiltViewModel()
+    val trafficViewModel : TrafficViewModel = hiltViewModel()
 
 
     SideEffect {
@@ -68,9 +69,10 @@ fun HomeRoute(
     HomeScreen(
         homeViewModel = homeViewModel,
         safetyViewModel = safetyViewModel,
+        trafficViewModel = trafficViewModel,
         onSearchClick = { navigator.navigateToSearch() },
-        onTrafficVisualizationClick = { navigator.navigateToTrafficVisualization() },
-        onSafetyVisualizationClick = { navigator.navigateToSafetyVisualization() }
+        onTrafficVisualizationClick = { navigator.navigateToTrafficVisualizationTemp() },
+        onSafetyVisualizationClick = { navigator.navigateToSafetyVisualizationTemp() }
     )
 }
 
@@ -79,6 +81,7 @@ fun HomeRoute(
 fun HomeScreen(
     homeViewModel: HomeViewModel,
     safetyViewModel: SafetyViewModel,
+    trafficViewModel: TrafficViewModel,
     onSearchClick: () -> Unit,
     onTrafficVisualizationClick: () -> Unit,
     onSafetyVisualizationClick: () -> Unit
@@ -182,6 +185,7 @@ fun HomeScreen(
                         bottomSheetScreen,
                         homeViewModel,
                         safetyViewModel,
+                        trafficViewModel,
                         onSearchClick,
                         onTrafficVisualizationClick,
                         onSafetyVisualizationClick,

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/SafetyVisualizationScreen_temp.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/SafetyVisualizationScreen_temp.kt
@@ -1,0 +1,175 @@
+package com.example.seollyongdan_frontend.presentation.home.screen
+
+import android.util.Log
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.seollyongdan_frontend.R
+import com.example.seollyongdan_frontend.presentation.home.navigation.HomeNavigator
+import com.example.seollyongdan_frontend.ui.component.CrimeBox
+import com.example.seollyongdan_frontend.ui.component.MainToVisualizationButton
+import com.example.seollyongdan_frontend.ui.component.VisualizationState
+import com.example.seollyongdan_frontend.ui.theme.Success900
+import com.example.seollyongdan_frontend.ui.theme.White
+import com.example.seollyongdan_frontend.ui.theme.h3Semi
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.map.CameraPosition
+import com.naver.maps.map.NaverMap
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+import com.naver.maps.map.compose.NaverMap
+import com.naver.maps.map.compose.rememberCameraPositionState
+
+
+@Composable
+fun SafetyVisualizationTempRoute(
+    navigator: HomeNavigator
+) {
+    val systemUiController = rememberSystemUiController()
+    val safetyVisualizationViewModel : SafetyVisualizationViewModel = hiltViewModel()
+
+    SideEffect {
+        systemUiController.setStatusBarColor(
+            color = Color.White
+        )
+    }
+
+    SafetyVisualizationScreen_temp(
+        onBackClick = { navigator.navigateBack() },
+        safetyVisualizationViewModel = safetyVisualizationViewModel
+    )
+}
+
+
+// 메인 화면 Composable
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalNaverMapApi::class)
+@Composable
+fun SafetyVisualizationScreen_temp(
+    onBackClick: () -> Unit,
+    safetyVisualizationViewModel : SafetyVisualizationViewModel
+) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        safetyVisualizationViewModel.getCrimeFreq()
+    }
+
+    // '높음', '낮음', '기타' 인덱스를 가져오기
+    val highCrimeIndexes = safetyVisualizationViewModel.highCrimeIndexes
+    val lowCrimeIndexes = safetyVisualizationViewModel.lowCrimeIndexes
+    val otherCrimeIndexes = safetyVisualizationViewModel.otherCrimeIndexes
+
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "범죄 발생 빈도",
+                            style = h3Semi,
+                            color = Success900
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(
+                            onClick =
+                            onBackClick
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_back),
+                                contentDescription = "Back"
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = White
+                    )
+                )
+            }
+        ) { paddingValues ->
+
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .padding(top = 20.dp)
+                    .padding(horizontal = 15.dp)
+
+            ) {
+
+                MainToVisualizationButton(
+                    onClick = {},
+                    text = "서울시 구별 범죄 발생 빈도"
+                )
+
+                Spacer(modifier = Modifier.height(25.dp))
+
+                Column {
+                    CrimeBox(highCrimeIndexes, "높음")
+
+                    Spacer(modifier = Modifier.height(5.dp))
+
+                    CrimeBox(otherCrimeIndexes, "보통")
+
+                    Spacer(modifier = Modifier.height(5.dp))
+
+                    CrimeBox(lowCrimeIndexes, "낮음")
+
+
+                }
+
+
+
+            }
+
+
+        }
+    }
+
+
+}
+
+
+
+@Preview
+@Composable
+fun SafetyVisualizationScreenTemPreview() {
+
+    val safetyData = listOf(
+        "high", "low", "average", "high",
+        "low", "average", "high", "low",
+        "average", "high", "low", "average",
+        "high", "low", "average", "high",
+        "low", "average", "high", "low",
+        "average", "high", "low", "average",
+        "high"
+    )
+
+    SafetyVisualizationScreen_temp(
+        onBackClick = {},
+        safetyVisualizationViewModel = viewModel()
+    )
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/SafetyVisualizationViewModel.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/SafetyVisualizationViewModel.kt
@@ -1,0 +1,50 @@
+package com.example.seollyongdan_frontend.presentation.home.screen
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.seollyongdan_frontend.domain.repository.HomeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SafetyVisualizationViewModel @Inject constructor(
+    private val repository: HomeRepository
+) : ViewModel() {
+
+    private val _highCrimeIndexes = mutableListOf<Int>()
+    val highCrimeIndexes: List<Int> get() = _highCrimeIndexes
+
+    private val _lowCrimeIndexes = mutableListOf<Int>()
+    val lowCrimeIndexes: List<Int> get() = _lowCrimeIndexes
+
+    private val _otherCrimeIndexes = mutableListOf<Int>()
+    val otherCrimeIndexes: List<Int> get() = _otherCrimeIndexes
+
+    fun getCrimeFreq() {
+        viewModelScope.launch {
+            val result = repository.getHomeCrimeFreq()
+            result.onSuccess { crimeFreqList ->
+                // 기존에 저장된 리스트를 비우고 새로 채운다.
+                _highCrimeIndexes.clear()
+                _lowCrimeIndexes.clear()
+                _otherCrimeIndexes.clear()
+
+                // "높음", "낮음", "기타"에 맞는 인덱스를 분류
+                crimeFreqList.forEachIndexed { index, value ->
+                    when (value) {
+                        "높음" -> _highCrimeIndexes.add(index+1)
+                        "낮음" -> _lowCrimeIndexes.add(index+1)
+                        else -> _otherCrimeIndexes.add(index+1)
+                    }
+                }
+            }.onFailure { exception ->
+                // 실패 처리
+                Log.e("SafetyVisualization", "Failed to load crime frequencies: ${exception.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/TrafficViewModel.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/TrafficViewModel.kt
@@ -1,0 +1,45 @@
+package com.example.seollyongdan_frontend.presentation.home.screen
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.seollyongdan_frontend.domain.repository.HomeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TrafficViewModel @Inject constructor(
+    private val repository: HomeRepository
+) : ViewModel() {
+
+    private var _busRatio: Float = 0f
+    val busRatio : Float = _busRatio
+
+    private var _subwayRatio: Float = 0f
+    val subwayRatio : Float = _subwayRatio
+
+    private var _taxiRatio: Float = 0f
+    val taxiRatio : Float = _taxiRatio
+
+    private var _mostUsedTransport : String = ""
+    val mostUsedTransport : String = _mostUsedTransport
+
+    private var _isHigh : Boolean = false
+    val isHigh : Boolean = _isHigh
+
+
+    fun getHomeTraffic(townId: Int) {
+        viewModelScope.launch {
+            val result = repository.getHomeTraffic(townId)
+            result.onSuccess { response ->
+                _busRatio = response.busRatio
+                _subwayRatio = response.subwayRatio
+                _taxiRatio = response.taxiRatio
+                _mostUsedTransport = response.mostUsedTransport
+                _isHigh = response.isHigh
+            }.onFailure {
+
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/TrafficVisualizationScreen_temp.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/TrafficVisualizationScreen_temp.kt
@@ -1,0 +1,164 @@
+package com.example.seollyongdan_frontend.presentation.home.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.seollyongdan_frontend.R
+import com.example.seollyongdan_frontend.presentation.home.navigation.HomeNavigator
+import com.example.seollyongdan_frontend.ui.component.CrimeBox
+import com.example.seollyongdan_frontend.ui.component.MainToVisualizationButton
+import com.example.seollyongdan_frontend.ui.theme.Success900
+import com.example.seollyongdan_frontend.ui.theme.White
+import com.example.seollyongdan_frontend.ui.theme.h3Semi
+import com.google.accompanist.systemuicontroller.rememberSystemUiController
+import com.naver.maps.map.compose.ExperimentalNaverMapApi
+
+
+@Composable
+fun TrafficVisualizationTempRoute(
+    navigator: HomeNavigator
+) {
+    val systemUiController = rememberSystemUiController()
+    val trafficVisualizationViewModel : TrafficVisualizationViewModel = hiltViewModel()
+
+    SideEffect {
+        systemUiController.setStatusBarColor(
+            color = Color.White
+        )
+    }
+
+    TrafficVisualizationScreen_temp(
+        onBackClick = { navigator.navigateBack() },
+        trafficVisualizationViewModel = trafficVisualizationViewModel
+    )
+}
+
+
+// 메인 화면 Composable
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalNaverMapApi::class)
+@Composable
+fun TrafficVisualizationScreen_temp(
+    onBackClick: () -> Unit,
+    trafficVisualizationViewModel: TrafficVisualizationViewModel
+) {
+    val context = LocalContext.current
+
+    LaunchedEffect(Unit) {
+        trafficVisualizationViewModel.getCongestion()
+    }
+
+    // '높음', '낮음', '기타' 인덱스를 가져오기
+    val highCongestionIndexes = trafficVisualizationViewModel.highCongestionIndexes
+    val lowCongestionIndexes = trafficVisualizationViewModel.lowCongestionIndexes
+    val otherCongestionIndexes = trafficVisualizationViewModel.otherCongestionIndexes
+
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "교통 혼잡도",
+                            style = h3Semi,
+                            color = Success900
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(
+                            onClick =
+                            onBackClick
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_back),
+                                contentDescription = "Back"
+                            )
+                        }
+                    },
+                    colors = TopAppBarDefaults.topAppBarColors(
+                        containerColor = White
+                    )
+                )
+            }
+        ) { paddingValues ->
+
+            Column(
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .padding(top = 20.dp)
+                    .padding(horizontal = 15.dp)
+            ) {
+
+                MainToVisualizationButton(
+                    onClick = {},
+                    text = "서울시 구별 교통 혼잡도"
+                )
+
+                Spacer(modifier = Modifier.height(25.dp))
+
+                Column {
+                    CrimeBox(highCongestionIndexes, "높음")
+
+                    Spacer(modifier = Modifier.height(5.dp))
+
+                    CrimeBox(otherCongestionIndexes, "보통")
+
+                    Spacer(modifier = Modifier.height(5.dp))
+
+                    CrimeBox(lowCongestionIndexes, "낮음")
+
+                }
+
+
+
+            }
+
+
+        }
+    }
+
+
+}
+
+
+
+@Preview
+@Composable
+fun TrafficVisualizationScreenTemPreview() {
+
+    val safetyData = listOf(
+        "high", "low", "average", "high",
+        "low", "average", "high", "low",
+        "average", "high", "low", "average",
+        "high", "low", "average", "high",
+        "low", "average", "high", "low",
+        "average", "high", "low", "average",
+        "high"
+    )
+
+    TrafficVisualizationScreen_temp(
+        onBackClick = {},
+        trafficVisualizationViewModel = viewModel()
+    )
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/TrafficVisualizationViewModel.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/presentation/home/screen/TrafficVisualizationViewModel.kt
@@ -1,0 +1,48 @@
+package com.example.seollyongdan_frontend.presentation.home.screen
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.seollyongdan_frontend.domain.repository.HomeRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class TrafficVisualizationViewModel @Inject constructor(
+    private val repository: HomeRepository
+) : ViewModel() {
+
+    private val _highCongestionIndexes = mutableListOf<Int>()
+    val highCongestionIndexes: List<Int> get() = _highCongestionIndexes
+
+    private val _lowCongestionIndexes = mutableListOf<Int>()
+    val lowCongestionIndexes: List<Int> get() = _lowCongestionIndexes
+
+    private val _otherCongestionIndexes = mutableListOf<Int>()
+    val otherCongestionIndexes: List<Int> get() = _otherCongestionIndexes
+
+    fun getCongestion() {
+        viewModelScope.launch {
+            val result = repository.getHomeCongestion()
+            result.onSuccess { congestionList ->
+                // 기존에 저장된 리스트를 비우고 새로 채운다.
+                _highCongestionIndexes.clear()
+                _lowCongestionIndexes.clear()
+                _otherCongestionIndexes.clear()
+
+                congestionList.forEachIndexed { index, value ->
+                    when (value) {
+                        "혼잡" -> _highCongestionIndexes.add(index+1)
+                        "보통" -> _otherCongestionIndexes.add(index+1)
+                        else -> _lowCongestionIndexes.add(index+1)
+
+                    }
+                }
+            }.onFailure { exception ->
+                // 실패 처리
+                Log.e("SafetyVisualization", "Failed to load crime frequencies: ${exception.message}")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/ui/component/CrimeBox.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/ui/component/CrimeBox.kt
@@ -1,0 +1,64 @@
+package com.example.seollyongdan_frontend.ui.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.seollyongdan_frontend.ui.theme.h5Semi
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun CrimeBox (
+    list : List<Int>,
+    type : String
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .wrapContentHeight()
+    ) {
+
+        Text(
+            text = when (type){
+                "높음" -> "상위에 속해요"
+                "낮음" -> "하위에 속해요"
+                else -> "평균이에요"
+
+            }, style = h5Semi
+        )
+
+        Spacer(modifier = Modifier.height(10.dp))
+
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(9.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            maxItemsInEachRow = 9
+        ) {
+            list.forEach { item ->
+                DistrictWrapBox(
+                    townId = item,
+                    type = type
+                )
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+fun CrimeBoxPreview(){
+    val list = listOf(1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25)
+    CrimeBox(list, "평균")
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/ui/component/DistrictWrapBox.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/ui/component/DistrictWrapBox.kt
@@ -1,0 +1,57 @@
+package com.example.seollyongdan_frontend.ui.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.seollyongdan_frontend.presentation.home.screen.townIdToTownName
+import com.example.seollyongdan_frontend.ui.theme.Info200
+import com.example.seollyongdan_frontend.ui.theme.Info400
+import com.example.seollyongdan_frontend.ui.theme.Primary600
+import com.example.seollyongdan_frontend.ui.theme.Warning100
+import com.example.seollyongdan_frontend.ui.theme.b1Semi
+
+@Composable
+fun DistrictWrapBox(
+    townId : Int,
+    type : String
+) {
+    val townName = townIdToTownName(townId)
+
+    val color = when(type){
+        "높음" -> Info200
+        "낮음" -> Primary600
+        else -> Warning100
+
+    }
+
+    Box(modifier = Modifier
+        .height(31.dp)
+        .wrapContentWidth()
+        .clip(RoundedCornerShape(20.dp))
+        .background(color),
+        contentAlignment = Alignment.Center
+    ){
+        Text(townName, style = b1Semi, modifier = Modifier.padding(horizontal = 15.dp))
+    }
+}
+
+@Preview
+@Composable
+fun DistrictWrapBoxPreview(){
+    DistrictWrapBox(
+        townId = 24,
+        type = "낮음"
+    )
+
+
+}

--- a/app/src/main/java/com/example/seollyongdan_frontend/ui/component/MainToVisualizationButton.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/ui/component/MainToVisualizationButton.kt
@@ -48,7 +48,7 @@ fun MainToVisualizationButton(
                 modifier = Modifier
                     .weight(1f)
             ) {
-                Text("지도로 한 눈에 보는", style = b4Semi, color = White)
+                Text("한 눈에 보는", style = b4Semi, color = White)
                 Spacer(modifier = Modifier.height(5.dp))
                 Text(text, style = h7Bold, color = White)
             }

--- a/app/src/main/java/com/example/seollyongdan_frontend/ui/component/TrafficTable.kt
+++ b/app/src/main/java/com/example/seollyongdan_frontend/ui/component/TrafficTable.kt
@@ -34,14 +34,15 @@ fun TrafficTable(
     val tableData = listOf(
         listOf("시설명", "비율"), // 헤더
         listOf("버스", data[0]),
-        listOf("지하철", data[1])
+        listOf("지하철", data[1]),
+        listOf("택시", data[2])
     )
 
     Column(
         modifier = Modifier
             .width(310.dp)
             .clip(RoundedCornerShape(8.dp))
-            .height(108.dp)
+            .height(148.dp)
             .border(1.dp, Gray200, RoundedCornerShape(8.dp))
     ) {
         tableData.forEachIndexed { rowIndex, row ->
@@ -83,6 +84,6 @@ fun TrafficTable(
 @Preview
 @Composable
 fun TrafficTablePreview(){
-    val data = listOf("100","200")
+    val data = listOf("100","200","300")
     TrafficTable(data)
 }


### PR DESCRIPTION
### ✨ 관련된 이슈
- close #21 

### 🙌 작업 내용
- 교통, 안전 및 치안 바텀시트 api 연동 구조 잡기
- 시각화 페이지 api 연동 구조 잡기

### 📸 스크린샷 (선택)
- 

### 🤔 리뷰 요구사항(선택)
- 아직 api 명세서대로 배포가 안 된 상황이라 api 명세서 형태대로 틀만 잡았습니다
- 실행 시 기대한대로 안 보일 뿐, 화면 자체에서 오류가 나진 않습니다
- 시각화 페이지는 아무래도 데모데이까지 해결이 어려울 거 같아 텍스트로 카테고리별 지역구를 보여주는 임시 페이지를 구현했습니다 (피그마 참고!)